### PR TITLE
change overflow scroll to auto.css

### DIFF
--- a/docs/assets/style/web.css
+++ b/docs/assets/style/web.css
@@ -452,7 +452,7 @@ nav.subnav {
   max-height: calc(100vh - (var(--gap) * 6));
   padding-left: calc(var(--gap) / 2);
   font-size: 0.9rem;
-  overflow: scroll;
+  overflow: auto;
 
   & ol {
     list-style: none;


### PR DESCRIPTION
Ik heb de nav.subnav  scrollbar de overflow scroll varvangen voor auto. Door dit te hebben gedaan is de horizontale scrollbar weg en de verticale scrollbar alleen aanwezig als je overflow hebt. 

Dit is mooier voor de mensen die niet safari gebruiken.